### PR TITLE
feat: use Haiku to generate conversation titles from content

### DIFF
--- a/src/utils/claudeExecutable.ts
+++ b/src/utils/claudeExecutable.ts
@@ -1,0 +1,88 @@
+/**
+ * Utility for finding the Claude Code CLI executable.
+ * Shared between AgentController and ConversationManager.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import { logger } from "./Logger";
+
+/**
+ * Find the Claude Code CLI executable path.
+ * Searches common installation locations including nvm-managed Node versions.
+ * @returns The path to the Claude executable, or undefined if not found.
+ */
+export function findClaudeExecutable(): string | undefined {
+  const homeDir = os.homedir();
+
+  // Common locations to check.
+  const possiblePaths: string[] = [
+    // User's npm global bin from NVM_BIN env var.
+    process.env.NVM_BIN ? `${process.env.NVM_BIN}/claude` : null,
+
+    // Common nvm paths - check multiple node versions.
+    `${homeDir}/.nvm/versions/node/v20.11.1/bin/claude`,
+    `${homeDir}/.nvm/versions/node/v22.0.0/bin/claude`,
+    `${homeDir}/.nvm/versions/node/v21.0.0/bin/claude`,
+    `${homeDir}/.nvm/versions/node/v18.0.0/bin/claude`,
+
+    // npm global without nvm.
+    `${homeDir}/.npm-global/bin/claude`,
+    `${homeDir}/npm/bin/claude`,
+
+    // Standard npm global.
+    "/usr/local/bin/claude",
+
+    // Homebrew on macOS.
+    "/opt/homebrew/bin/claude",
+
+    // Linux global.
+    "/usr/bin/claude",
+  ].filter((p): p is string => p !== null);
+
+  // Also check all nvm versions dynamically.
+  const nvmDir = `${homeDir}/.nvm/versions/node`;
+  try {
+    if (fs.existsSync(nvmDir)) {
+      const versions = fs.readdirSync(nvmDir);
+      for (const ver of versions) {
+        const claudePath = path.join(nvmDir, ver, "bin", "claude");
+        if (!possiblePaths.includes(claudePath)) {
+          possiblePaths.push(claudePath);
+        }
+      }
+    }
+  } catch {
+    // Ignore errors reading nvm directory.
+  }
+
+  // Check if any exist.
+  for (const p of possiblePaths) {
+    try {
+      if (fs.existsSync(p)) {
+        logger.info("ClaudeExecutable", "Found Claude executable", { path: p });
+        return p;
+      }
+    } catch {
+      // Ignore individual path check errors.
+    }
+  }
+
+  // Log all paths we checked.
+  logger.warn("ClaudeExecutable", "Could not find Claude executable", { checkedPaths: possiblePaths });
+  return undefined;
+}
+
+/**
+ * Find the Claude Code CLI executable path, throwing if not found.
+ * Use this variant when Claude is required and its absence is an error.
+ * @throws Error if Claude CLI is not found.
+ */
+export function requireClaudeExecutable(): string {
+  const executable = findClaudeExecutable();
+  if (!executable) {
+    throw new Error("Claude Code CLI not found. Please install it with: npm install -g @anthropic-ai/claude-code");
+  }
+  return executable;
+}

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -3,6 +3,10 @@
  * Extracted for testability.
  */
 
+import * as path from "path";
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import { logger } from "./Logger";
+
 /**
  * Format a duration in milliseconds to a human-readable string.
  */
@@ -27,6 +31,7 @@ export function truncateText(text: string, maxLength: number): string {
 
 /**
  * Generate a title from content (first line, truncated to 50 chars).
+ * This is the fallback method when Haiku title generation is not available or fails.
  */
 export function generateTitle(content: string): string {
   const firstLine = content.split("\n")[0];
@@ -34,6 +39,121 @@ export function generateTitle(content: string): string {
     return firstLine;
   }
   return firstLine.slice(0, 47) + "...";
+}
+
+/**
+ * Generate a conversation title using Claude Haiku based on the conversation content.
+ * @param userMessage The first user message content
+ * @param assistantMessage The first assistant response content
+ * @param apiKey The Anthropic API key (from settings or env)
+ * @param claudeExecutable Path to the Claude CLI executable
+ * @param cwd Working directory for the SDK (vault path)
+ * @returns A promise that resolves to a concise title, or null if generation fails
+ */
+export async function generateTitleWithHaiku(
+  userMessage: string,
+  assistantMessage: string,
+  apiKey?: string,
+  claudeExecutable?: string,
+  cwd?: string
+): Promise<string | null> {
+  try {
+    // Check for any form of authentication (API key or OAuth token).
+    const hasApiKey = !!(apiKey || process.env.ANTHROPIC_API_KEY);
+    const hasOAuthToken = !!process.env.CLAUDE_CODE_OAUTH_TOKEN;
+
+    if (!hasApiKey && !hasOAuthToken) {
+      logger.debug("TitleGeneration", "No authentication available for Haiku title generation");
+      return null;
+    }
+
+    // Build environment - include full process.env for OAuth support.
+    const env: Record<string, string | undefined> = { ...process.env };
+    // Override API key if explicitly provided in settings.
+    if (apiKey) {
+      env.ANTHROPIC_API_KEY = apiKey;
+    }
+
+    // Add claude executable path to PATH if provided.
+    if (claudeExecutable) {
+      const claudeDir = path.dirname(claudeExecutable);
+      if (env.PATH && !env.PATH.includes(claudeDir)) {
+        env.PATH = `${claudeDir}:${env.PATH}`;
+      } else if (!env.PATH) {
+        env.PATH = claudeDir;
+      }
+    }
+
+    // Limit messages to avoid excessive tokens
+    const userPreview = userMessage.slice(0, 500);
+    const assistantPreview = assistantMessage.slice(0, 500);
+    
+    // Create a simple prompt for title generation
+    const titlePrompt = `Generate a concise title (max 50 characters) for this conversation. Reply with ONLY the title:
+
+User: ${userPreview}
+Assistant: ${assistantPreview}`;
+
+    logger.debug("TitleGeneration", "Calling Haiku for title generation");
+
+    let generatedTitle = "";
+
+    // Create an AbortController for this request.
+    const abortController = new AbortController();
+
+    // Use the Agent SDK query function with Haiku model.
+    for await (const message of query({
+      prompt: titlePrompt,
+      options: {
+        abortController,
+        cwd,
+        env,
+        pathToClaudeCodeExecutable: claudeExecutable,
+        model: "haiku",
+        // Minimal settings for quick title generation.
+        maxBudgetUsd: 0.05, // Very low budget for just a title.
+        // No tools needed for title generation.
+        tools: [],
+        systemPrompt: "Generate a concise title. Reply with only the title text.",
+      },
+    })) {
+      // Extract text from assistant messages
+      if (message.type === "assistant") {
+        const content = message.message.content;
+        if (Array.isArray(content)) {
+          for (const block of content) {
+            if (block.type === "text") {
+              generatedTitle += block.text;
+            }
+          }
+        }
+      } else if (message.type === "result" && message.subtype === "success") {
+        // Query completed successfully
+        break;
+      } else if (message.type === "result") {
+        // Query failed
+        logger.warn("TitleGeneration", "Haiku query failed", { subtype: message.subtype });
+        return null;
+      }
+    }
+
+    // Clean up and validate the title
+    const title = generatedTitle.trim();
+    if (!title) {
+      logger.debug("TitleGeneration", "Haiku returned empty title");
+      return null;
+    }
+
+    // Ensure it's not too long
+    const finalTitle = title.length <= 50 ? title : title.slice(0, 47) + "...";
+    
+    logger.debug("TitleGeneration", "Generated title with Haiku", { title: finalTitle });
+    return finalTitle;
+
+  } catch (error) {
+    logger.warn("TitleGeneration", "Failed to generate title with Haiku", { error: String(error) });
+    return null;
+  }
 }
 
 /**


### PR DESCRIPTION
Implemented smart conversation title generation using Claude Haiku:

- Added generateTitleWithHaiku() function that uses the Agent SDK
  to call Haiku with first user + assistant messages
- Updated ConversationManager to generate titles after the first
  assistant response (messageCount === 2) instead of first user message
- Added fallback to simple title generation if Haiku is unavailable
  or fails
- Updated tests to accommodate new title generation timing and
  mocked Haiku calls for testing

The title is now generated based on conversation context rather than
just truncating the first message, providing more descriptive and
meaningful conversation titles.