### PR TITLE
fix: detect Claude CLI in ~/.local/bin

### DIFF
--- a/src/utils/claudeExecutable.ts
+++ b/src/utils/claudeExecutable.ts
@@ -27,6 +27,9 @@ export function findClaudeExecutable(): string | undefined {
     `${homeDir}/.nvm/versions/node/v21.0.0/bin/claude`,
     `${homeDir}/.nvm/versions/node/v18.0.0/bin/claude`,
 
+    // User local bin (common for pip/pipx installs and manual installs).
+    `${homeDir}/.local/bin/claude`,
+
     // npm global without nvm.
     `${homeDir}/.npm-global/bin/claude`,
     `${homeDir}/npm/bin/claude`,


### PR DESCRIPTION
## Summary
- Adds `~/.local/bin/claude` to the list of paths checked when searching for the Claude Code CLI executable
- This is a common location for user-installed binaries (native installs, manual installs)

## Test plan
- [x] Verified plugin finds Claude at `~/.local/bin/claude` after rebuild
- [x] Plugin works end-to-end with this path detected